### PR TITLE
Improvements

### DIFF
--- a/PowerSession.Cli/Program.cs
+++ b/PowerSession.Cli/Program.cs
@@ -14,7 +14,7 @@
             var record = new Command("rec")
             {
                 new Argument<FileInfo>("file"){Description = "The filename to save the record"},
-                new Option(new []{"--command", "-c"}, "The command to record, default to be powershell.exe", typeof(string))
+                new Option(new []{"--command", "-c"}, "The command to record, defaults to $SHELL", typeof(string))
             };
             record.Description = "Record and save a session";
             record.Handler = CommandHandler.Create((FileInfo file, string command) =>

--- a/PowerSession.ConPTY/Terminal.cs
+++ b/PowerSession.ConPTY/Terminal.cs
@@ -52,7 +52,7 @@ namespace PowerSession.Main.ConPTY
 
             _width = width == 0 ? Console.WindowWidth : width;
             _height = height == 0 ? Console.WindowHeight : height;
-            
+
             _tokenSource = new CancellationTokenSource();
             _token = _tokenSource.Token;
         }
@@ -62,7 +62,7 @@ namespace PowerSession.Main.ConPTY
             using var inputPipe = new PseudoConsolePipe();
             using var outputPipe = new PseudoConsolePipe();
             using var pseudoConsole = PseudoConsole.Create(inputPipe.ReadSide, outputPipe.WriteSide, _width, _height);
-            using var process = ProcessFactory.Start(command, PseudoConsole.PseudoConsoleThreadAttribute,
+            using var process = ProcessFactory.Start($"powershell.exe -c {command}", PseudoConsole.PseudoConsoleThreadAttribute,
                 pseudoConsole.Handle);
             _consoleOutStream = new FileStream(outputPipe.ReadSide, FileAccess.Read);
 
@@ -110,7 +110,7 @@ namespace PowerSession.Main.ConPTY
                         case ConsoleKey.LeftArrow:
                             _consoleInputWriter.Write(LeftArrow);
                             break;
-                        default:                 
+                        default:
                             _consoleInputWriter.Write(key.KeyChar);
                             break;
                     }

--- a/PowerSession.ConPTY/Terminal.cs
+++ b/PowerSession.ConPTY/Terminal.cs
@@ -62,7 +62,8 @@ namespace PowerSession.Main.ConPTY
             using var inputPipe = new PseudoConsolePipe();
             using var outputPipe = new PseudoConsolePipe();
             using var pseudoConsole = PseudoConsole.Create(inputPipe.ReadSide, outputPipe.WriteSide, _width, _height);
-            using var process = ProcessFactory.Start($"powershell.exe -c {command}", PseudoConsole.PseudoConsoleThreadAttribute,
+
+            using var process = ProcessFactory.Start($"powershell.exe -c \"Set-Item -Path Env:POWERSESSION_RECORDING -Value 1;{command}\"", PseudoConsole.PseudoConsoleThreadAttribute,
                 pseudoConsole.Handle);
             _consoleOutStream = new FileStream(outputPipe.ReadSide, FileAccess.Read);
 

--- a/PowerSession.Main/Api/AsciinemaApi.cs
+++ b/PowerSession.Main/Api/AsciinemaApi.cs
@@ -1,12 +1,14 @@
-﻿namespace PowerSession.Main.Api
+﻿
+namespace PowerSession.Main.Api
 {
     using System;
     using System.IO;
     using System.Net.Http;
+    using System.Linq;
     using System.Net.Http.Headers;
-    using System.Runtime.InteropServices;
     using System.Text;
     using PowerSession.Api;
+    using System.Reflection;
 
     public class AsciinemaApi : IApiService
     {
@@ -15,9 +17,11 @@
         private string AuthUrl => $"{ApiHost}/connect/{AppConfig.InstallId}";
         private string UploadUrl => $"{ApiHost}/api/asciicasts";
 
-        private static readonly string RuntimeFramework = $"NetCoreApp/{Environment.Version.Major}.{Environment.Version.Minor}";
-        private static readonly string OperatingSystem = $"Windows {Environment.OSVersion.Version.Major}-{Environment.OSVersion.VersionString}";
-        
+
+        private static readonly OperatingSystem Os = Environment.OSVersion;
+        private static readonly string RuntimeFramework = $"dotnet/{Environment.Version.Major}.{Environment.Version.Minor}.{Environment.Version.Build}";
+        private static readonly string OperatingSystem = $"Windows/{Os.Version.Major}-{Os.Version.Major}.{Os.Version.Minor}.{Os.Version.Build}-SP{Os.ServicePack.Split(' ').Skip(2).FirstOrDefault() ?? "0"}";
+
         public string Upload(string filePath)
         {
             var req = new MultipartFormDataContent();
@@ -40,12 +44,12 @@
             _httpClient = new HttpClient();
             _httpClient.DefaultRequestHeaders.Accept.Clear();
             _httpClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(System.Net.Mime.MediaTypeNames.Application.Json));
-            
+
             _httpClient.DefaultRequestHeaders.Add("User-Agent",$"asciinema/2.0.0 {RuntimeFramework} {OperatingSystem}");
-            
+
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"user:{AppConfig.InstallId}")));
         }
-        
+
         public void Auth()
         {
             Console.WriteLine("Open the following URL in a web browser to link your" +

--- a/PowerSession.Main/Commands/RecordCommand.cs
+++ b/PowerSession.Main/Commands/RecordCommand.cs
@@ -64,7 +64,7 @@
             }
         }
 
-        private static string _getTerm()
+        private static string GetTerm()
         {
             return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WT_SESSION")) ? "windows-terminal" :
                 Environment.GetEnvironmentVariable("TERM");
@@ -72,12 +72,15 @@
 
         private void _record(string filename, string command = null)
         {
-            command ??= Environment.GetEnvironmentVariable("SHELL") ?? "powershell.exe";
+            if (string.IsNullOrEmpty(command))
+            {
+                command = Environment.GetEnvironmentVariable("SHELL") ?? "powershell.exe";
+            }
 
             _env ??= new Dictionary<string, string>();
             _env.Add("SHELL", Environment.GetEnvironmentVariable("SHELL") ?? "powershell.exe");
 
-            string term = _getTerm();
+            string term = GetTerm();
             if (!string.IsNullOrWhiteSpace(term))
             {
                 _env.Add("TERM", term);

--- a/PowerSession.Main/Commands/RecordCommand.cs
+++ b/PowerSession.Main/Commands/RecordCommand.cs
@@ -1,12 +1,12 @@
 ﻿namespace PowerSession.Main.Commands
 {
+    using ConPTY;
+    using Newtonsoft.Json;
+    using PowerSession.Commands;
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
-    using ConPTY;
-    using Newtonsoft.Json;
-    using PowerSession.Commands;
     using Utils;
 
     public struct RecordHeader
@@ -64,14 +64,25 @@
             }
         }
 
+        private static string _getTerm()
+        {
+            return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WT_SESSION")) ? "windows-terminal" :
+                Environment.GetEnvironmentVariable("TERM");
+        }
+
         private void _record(string filename, string command = null)
         {
             if (string.IsNullOrEmpty(command)) command = "powershell.exe";
 
-            if (_env == null) _env = new Dictionary<string, string>();
+            _env ??= new Dictionary<string, string>();
             _env.Add("POWERSESSION_RECORDING", "1");
             _env.Add("SHELL", "powershell.exe");
-            _env.Add("TERM", Environment.GetEnvironmentVariable("TERMINAL_EMULATOR") ?? "NotSure");
+
+            string term = _getTerm();
+            if (!string.IsNullOrWhiteSpace(term))
+            {
+                _env.Add("TERM", term);
+            }
 
             using var writer = new FileWriter(filename);
             var headerInfo = new RecordHeader

--- a/PowerSession.Main/Commands/RecordCommand.cs
+++ b/PowerSession.Main/Commands/RecordCommand.cs
@@ -72,11 +72,10 @@
 
         private void _record(string filename, string command = null)
         {
-            if (string.IsNullOrEmpty(command)) command = "powershell.exe";
+            command ??= Environment.GetEnvironmentVariable("SHELL") ?? "powershell.exe";
 
             _env ??= new Dictionary<string, string>();
-            _env.Add("POWERSESSION_RECORDING", "1");
-            _env.Add("SHELL", "powershell.exe");
+            _env.Add("SHELL", Environment.GetEnvironmentVariable("SHELL") ?? "powershell.exe");
 
             string term = _getTerm();
             if (!string.IsNullOrWhiteSpace(term))


### PR DESCRIPTION
- Make User-Agent close to how asciinema does it
- Don't add TERM variable if not found instead of `NotSure`
- Add Windows Terminal detection
- Default command to `$SHELL`, fallback to `powershell.exe`
- Add POWERSESSION_RECORDING directly in command (Recorder should only capture `SHELL` and `TERM` by default)