### PR TITLE
Add scoop installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ PowerShell version of [asciinema](https://github.com/asciinema/asciinema) based 
 
 ## Installation
 
+### Cargo
 ```console
 cargo install PowerSession
+```
+
+### Scoop
+```console
+scoop install powersession
 ```
 
 ## Usage


### PR DESCRIPTION
Currently, Scoop installs the C# version. Would you like to create a v2.0.0 tag for rust (I would recommend this, changes in C# would stay in v1), or should I change the `autoupdate` for the tag instead?